### PR TITLE
support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 
 [lib]
-crate-type = ["lib"]
+crate-type = ["rlib"]
 
 [dependencies]
 serde = {version = "1.0.102", features=["std", "derive"], optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ rust-version = "1.60"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["lib"]
 
 [dependencies]
 serde = {version = "1.0.102", features=["std", "derive"], optional = true}
 pyo3 = {version = "0.16", features=["extension-module", "abi3-py37"], optional = true }
 wasm-bindgen = {version = "0.2", optional = true}
 js-sys = {version = "0.3.60", optional = true}
+micromath = {version = "2.0.0", optional = true}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -43,15 +44,28 @@ harness = false
 name = "decode_benchmark"
 harness = false
 
+[[example]]
+name = "main"
+required-features = ["std"]
+
 [profile.release]
 debug = true
 lto = false
 
 [features]
-benchmarking = []
-python = ["pyo3"]
-serde_support = ["serde"]
-wasm = ["wasm-bindgen", "js-sys"]
+default = ["std"]
+
+benchmarking = ["std"]
+python = ["pyo3", "std"]
+serde_support = ["serde", "std"]
+std = []
+wasm = ["wasm-bindgen", "js-sys", "std"]
+
+# Provides `no_std` compatibility in `default-features = false, features = ["metal"]`
+# configuration.
+# Either one of `std`-compatible features or `metal` should be enabled for
+# crate functionality.
+metal = ["micromath"]
 
 [package.metadata.maturin]
 requires-python = ">= 3.7"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,13 @@
+#[cfg(not(feature = "python"))]
 use rand::seq::SliceRandom;
+
+#[cfg(not(feature = "python"))]
 use rand::Rng;
+
+#[cfg(not(feature = "python"))]
 use raptorq::{Decoder, Encoder, EncodingPacket};
 
+#[cfg(not(feature = "python"))]
 fn main() {
     // Generate some random data to send
     let mut data: Vec<u8> = vec![0; 10_000];
@@ -42,4 +48,9 @@ fn main() {
 
     // Check that even though some of the data was lost we are able to reconstruct the original message
     assert_eq!(result.unwrap(), data);
+}
+
+#[cfg(feature = "python")]
+fn main() {
+    panic!("This is not indented to compile for `python` feature");
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,13 +1,13 @@
-#[cfg(not(feature = "python"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 use rand::seq::SliceRandom;
 
-#[cfg(not(feature = "python"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 use rand::Rng;
 
-#[cfg(not(feature = "python"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 use raptorq::{Decoder, Encoder, EncodingPacket};
 
-#[cfg(not(feature = "python"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 fn main() {
     // Generate some random data to send
     let mut data: Vec<u8> = vec![0; 10_000];
@@ -50,7 +50,7 @@ fn main() {
     assert_eq!(result.unwrap(), data);
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "wasm"))]
 fn main() {
-    panic!("This is not indented to compile for `python` feature");
+    panic!("This is not indented to compile for `python` and `wasm` features.");
 }

--- a/src/arraymap.rs
+++ b/src/arraymap.rs
@@ -1,5 +1,11 @@
-use std::mem::size_of;
-use std::ops::Range;
+#[cfg(feature = "std")]
+use std::{u32, mem::size_of, ops::Range, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::{u32, mem::size_of, ops::Range};
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 // Map<u16, Vec<u32>>
@@ -50,9 +56,9 @@ impl ImmutableListMapBuilder {
     pub fn build(self) -> ImmutableListMap {
         let mut entries = self.entries;
         entries.sort_unstable_by_key(|x| x.0);
-        assert!(entries.len() < std::u32::MAX as usize);
+        assert!(entries.len() < u32::MAX as usize);
         assert!(!entries.is_empty());
-        let mut offsets = vec![std::u32::MAX; self.num_keys];
+        let mut offsets = vec![u32::MAX; self.num_keys];
         let mut last_key = entries[0].0;
         offsets[last_key as usize] = 0;
         let mut values = vec![];
@@ -64,7 +70,7 @@ impl ImmutableListMapBuilder {
             values.push(*value);
         }
         for i in (0..offsets.len()).rev() {
-            if offsets[i] == std::u32::MAX {
+            if offsets[i] == u32::MAX {
                 if i == offsets.len() - 1 {
                     offsets[i] = entries.len() as u32;
                 } else {

--- a/src/arraymap.rs
+++ b/src/arraymap.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "std")]
-use std::{u32, mem::size_of, ops::Range, vec::Vec};
+use std::{mem::size_of, ops::Range, u32, vec::Vec};
 
 #[cfg(feature = "metal")]
-use core::{u32, mem::size_of, ops::Range};
+use core::{mem::size_of, ops::Range, u32};
 
 #[cfg(feature = "metal")]
 use alloc::vec::Vec;

--- a/src/base.rs
+++ b/src/base.rs
@@ -135,8 +135,10 @@ impl ObjectTransmissionInformation {
         let symbols_required =
             ((transfer_length as f64 / symbol_size as f64).ceil() / source_blocks as f64).ceil();
         #[cfg(feature = "metal")]
-        let symbols_required =
-            ((F32(transfer_length as f32) / F32(symbol_size as f32)).ceil() / F32(source_blocks as f32)).ceil().0;
+        let symbols_required = ((F32(transfer_length as f32) / F32(symbol_size as f32)).ceil()
+            / F32(source_blocks as f32))
+        .ceil()
+        .0;
         assert!((symbols_required as u32) <= MAX_SOURCE_SYMBOLS_PER_BLOCK);
         ObjectTransmissionInformation {
             transfer_length,
@@ -213,18 +215,22 @@ impl ObjectTransmissionInformation {
         let kt = (transfer_length as f64 / symbol_size as f64).ceil();
         #[cfg(feature = "metal")]
         let kt = (F32(transfer_length as f32) / F32(symbol_size as f32)).ceil();
-        
+
         #[cfg(feature = "std")]
         let n_max = (symbol_size as f64 / (sub_symbol_size * alignment) as f64).floor() as u32;
         #[cfg(feature = "metal")]
-        let n_max = (F32(symbol_size as f32) / F32((sub_symbol_size * alignment) as f32)).floor().0 as u32;
+        let n_max = (F32(symbol_size as f32) / F32((sub_symbol_size * alignment) as f32))
+            .floor()
+            .0 as u32;
 
         let kl = |n: u32| -> u32 {
             for &(kprime, _, _, _, _) in SYSTEMATIC_INDICES_AND_PARAMETERS.iter().rev() {
                 #[cfg(feature = "std")]
                 let x = (symbol_size as f64 / (alignment as u32 * n) as f64).ceil();
                 #[cfg(feature = "metal")]
-                let x = (F32(symbol_size as f32) / F32((alignment as u32 * n) as f32)).ceil().0 as f64;
+                let x = (F32(symbol_size as f32) / F32((alignment as u32 * n) as f32))
+                    .ceil()
+                    .0 as f64;
                 if kprime <= (decoder_memory_requirement as f64 / (alignment as f64 * x)) as u32 {
                     return kprime;
                 }
@@ -284,12 +290,12 @@ where
     let il = (i as f64 / j as f64).ceil() as u32;
     #[cfg(feature = "metal")]
     let il = (F32(i as f32) / F32(j as f32)).ceil().0 as u32;
-    
+
     #[cfg(feature = "std")]
     let is = (i as f64 / j as f64).floor() as u32;
     #[cfg(feature = "metal")]
     let is = (F32(i as f32) / F32(j as f32)).floor().0 as u32;
-    
+
     let jl = i - is * j;
     let js = j - jl;
     (il, is, jl, js)

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,10 +1,21 @@
+#[cfg(feature = "std")]
+use std::{cmp::min, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::cmp::min;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "metal")]
+use micromath::F32;
+
 use crate::rng::rand;
 use crate::systematic_constants::{
     MAX_SOURCE_SYMBOLS_PER_BLOCK, SYSTEMATIC_INDICES_AND_PARAMETERS,
 };
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
-use std::cmp::min;
 
 // As defined in section 3.2
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -108,6 +119,7 @@ pub struct ObjectTransmissionInformation {
 }
 
 impl ObjectTransmissionInformation {
+    #[cfg(any(feature = "std", feature = "metal"))]
     pub fn new(
         transfer_length: u64,
         symbol_size: u16,
@@ -119,8 +131,12 @@ impl ObjectTransmissionInformation {
         assert!(transfer_length <= 942574504275);
         assert_eq!(symbol_size % alignment as u16, 0);
         // See section 4.4.1.2. "These parameters MUST be set so that ceil(ceil(F/T)/Z) <= K'_max."
+        #[cfg(feature = "std")]
         let symbols_required =
             ((transfer_length as f64 / symbol_size as f64).ceil() / source_blocks as f64).ceil();
+        #[cfg(feature = "metal")]
+        let symbols_required =
+            ((F32(transfer_length as f32) / F32(symbol_size as f32)).ceil() / F32(source_blocks as f32)).ceil().0;
         assert!((symbols_required as u32) <= MAX_SOURCE_SYMBOLS_PER_BLOCK);
         ObjectTransmissionInformation {
             transfer_length,
@@ -182,6 +198,7 @@ impl ObjectTransmissionInformation {
         self.symbol_alignment
     }
 
+    #[cfg(any(feature = "std", feature = "metal"))]
     pub(crate) fn generate_encoding_parameters(
         transfer_length: u64,
         max_packet_size: u16,
@@ -192,12 +209,22 @@ impl ObjectTransmissionInformation {
         let symbol_size = max_packet_size - (max_packet_size % alignment);
         let sub_symbol_size = 8;
 
+        #[cfg(feature = "std")]
         let kt = (transfer_length as f64 / symbol_size as f64).ceil();
+        #[cfg(feature = "metal")]
+        let kt = (F32(transfer_length as f32) / F32(symbol_size as f32)).ceil();
+        
+        #[cfg(feature = "std")]
         let n_max = (symbol_size as f64 / (sub_symbol_size * alignment) as f64).floor() as u32;
+        #[cfg(feature = "metal")]
+        let n_max = (F32(symbol_size as f32) / F32((sub_symbol_size * alignment) as f32)).floor().0 as u32;
 
         let kl = |n: u32| -> u32 {
             for &(kprime, _, _, _, _) in SYSTEMATIC_INDICES_AND_PARAMETERS.iter().rev() {
+                #[cfg(feature = "std")]
                 let x = (symbol_size as f64 / (alignment as u32 * n) as f64).ceil();
+                #[cfg(feature = "metal")]
+                let x = (F32(symbol_size as f32) / F32((alignment as u32 * n) as f32)).ceil().0 as f64;
                 if kprime <= (decoder_memory_requirement as f64 / (alignment as f64 * x)) as u32 {
                     return kprime;
                 }
@@ -205,12 +232,20 @@ impl ObjectTransmissionInformation {
             unreachable!();
         };
 
+        #[cfg(feature = "std")]
         let num_source_blocks = (kt / kl(n_max) as f64).ceil() as u32;
+        #[cfg(feature = "metal")]
+        let num_source_blocks = (kt / F32(kl(n_max) as f32)).ceil().0 as u32;
 
         let mut n = 1;
         for i in 1..=n_max {
             n = i;
+            #[cfg(feature = "std")]
             if (kt / num_source_blocks as f64).ceil() as u32 <= kl(n) {
+                break;
+            }
+            #[cfg(feature = "metal")]
+            if (kt / F32(num_source_blocks as f32)).ceil().0 as u32 <= kl(n) {
                 break;
             }
         }
@@ -224,6 +259,7 @@ impl ObjectTransmissionInformation {
         }
     }
 
+    #[cfg(any(feature = "std", feature = "metal"))]
     pub fn with_defaults(
         transfer_length: u64,
         max_packet_size: u16,
@@ -236,6 +272,7 @@ impl ObjectTransmissionInformation {
     }
 }
 
+#[cfg(any(feature = "std", feature = "metal"))]
 // Partition[I, J] function, as defined in section 4.4.1.2
 pub fn partition<TI, TJ>(i: TI, j: TJ) -> (u32, u32, u32, u32)
 where
@@ -243,8 +280,16 @@ where
     TJ: Into<u32>,
 {
     let (i, j) = (i.into(), j.into());
+    #[cfg(feature = "std")]
     let il = (i as f64 / j as f64).ceil() as u32;
+    #[cfg(feature = "metal")]
+    let il = (F32(i as f32) / F32(j as f32)).ceil().0 as u32;
+    
+    #[cfg(feature = "std")]
     let is = (i as f64 / j as f64).floor() as u32;
+    #[cfg(feature = "metal")]
+    let is = (F32(i as f32) / F32(j as f32)).floor().0 as u32;
+    
     let jl = i - is * j;
     let js = j - jl;
     (il, is, jl, js)

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -185,7 +185,10 @@ mod tests {
         extended_source_block_symbols, num_hdpc_symbols, num_ldpc_symbols,
     };
     use rand::Rng;
+    #[cfg(feature = "std")]
     use std::vec::Vec;
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
 
     #[allow(non_snake_case)]
     fn reference_generate_hdpc_rows(Kprime: usize, S: usize, H: usize) -> DenseOctetMatrix {

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -184,11 +184,11 @@ mod tests {
     use crate::systematic_constants::{
         extended_source_block_symbols, num_hdpc_symbols, num_ldpc_symbols,
     };
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
 
     #[allow(non_snake_case)]
     fn reference_generate_hdpc_rows(Kprime: usize, S: usize, H: usize) -> DenseOctetMatrix {

--- a/src/constraint_matrix.rs
+++ b/src/constraint_matrix.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::base::intermediate_tuple;
 use crate::matrix::BinaryMatrix;
 use crate::octet::Octet;
@@ -179,6 +185,7 @@ mod tests {
         extended_source_block_symbols, num_hdpc_symbols, num_ldpc_symbols,
     };
     use rand::Rng;
+    use std::vec::Vec;
 
     #[allow(non_snake_case)]
     fn reference_generate_hdpc_rows(Kprime: usize, S: usize, H: usize) -> DenseOctetMatrix {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -43,10 +43,12 @@ impl Decoder {
     pub fn new(config: ObjectTransmissionInformation) -> Decoder {
         #[cfg(feature = "std")]
         let kt = (config.transfer_length() as f64 / config.symbol_size() as f64).ceil() as u32;
-        
+
         #[cfg(feature = "metal")]
-        let kt = (F32(config.transfer_length() as f32) / F32(config.symbol_size() as f32)).ceil().0 as u32;
-        
+        let kt = (F32(config.transfer_length() as f32) / F32(config.symbol_size() as f32))
+            .ceil()
+            .0 as u32;
+
         let (kl, ks, zl, zs) = partition(kt, config.source_blocks());
 
         let mut decoders = vec![];
@@ -73,7 +75,10 @@ impl Decoder {
         }
     }
 
-    #[cfg(all(any(test, feature = "benchmarking"), not(any(feature = "python", feature = "wasm"))))]
+    #[cfg(all(
+        any(test, feature = "benchmarking"),
+        not(any(feature = "python", feature = "wasm"))
+    ))]
     pub fn set_sparse_threshold(&mut self, value: u32) {
         for block_decoder in self.block_decoders.iter_mut() {
             block_decoder.set_sparse_threshold(value);
@@ -165,8 +170,10 @@ impl SourceBlockDecoder {
         #[cfg(feature = "std")]
         let source_symbols = (block_length as f64 / config.symbol_size() as f64).ceil() as u32;
         #[cfg(feature = "metal")]
-        let source_symbols = (F32(block_length as f32) / F32(config.symbol_size() as f32)).ceil().0 as u32;
-        
+        let source_symbols = (F32(block_length as f32) / F32(config.symbol_size() as f32))
+            .ceil()
+            .0 as u32;
+
         let mut received_esi = Set::new();
         for i in source_symbols..extended_source_block_symbols(source_symbols) {
             received_esi.insert(i);
@@ -358,27 +365,30 @@ impl SourceBlockDecoder {
 
 #[cfg(test)]
 mod codec_tests {
-    use crate::SourceBlockEncoder;
     #[cfg(not(any(feature = "python", feature = "wasm")))]
     use crate::Decoder;
+    use crate::SourceBlockEncoder;
     #[cfg(feature = "std")]
     use crate::SourceBlockEncodingPlan;
     #[cfg(not(any(feature = "python", feature = "wasm")))]
     use crate::{Encoder, EncoderBuilder};
     use crate::{ObjectTransmissionInformation, SourceBlockDecoder};
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
+    #[cfg(feature = "metal")]
+    use core::iter;
     #[cfg(not(any(feature = "python", feature = "wasm")))]
     use rand::seq::SliceRandom;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::{
         iter,
-        sync::{Arc, atomic::{AtomicU32, Ordering}},
+        sync::{
+            atomic::{AtomicU32, Ordering},
+            Arc,
+        },
         vec::Vec,
     };
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
-    #[cfg(feature = "metal")]
-    use core::iter;
 
     #[cfg(not(any(feature = "python", feature = "wasm")))]
     #[test]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -73,7 +73,7 @@ impl Decoder {
         }
     }
 
-    #[cfg(any(test, feature = "benchmarking"))]
+    #[cfg(all(any(test, feature = "benchmarking"), not(feature = "python")))]
     pub fn set_sparse_threshold(&mut self, value: u32) {
         for block_decoder in self.block_decoders.iter_mut() {
             block_decoder.set_sparse_threshold(value);
@@ -359,9 +359,13 @@ impl SourceBlockDecoder {
 #[cfg(test)]
 mod codec_tests {
     use crate::SourceBlockEncoder;
-    use crate::{Decoder, SourceBlockEncodingPlan};
+    #[cfg(not(feature = "python"))]
+    use crate::Decoder;
+    use crate::SourceBlockEncodingPlan;
+    #[cfg(not(feature = "python"))]
     use crate::{Encoder, EncoderBuilder};
     use crate::{ObjectTransmissionInformation, SourceBlockDecoder};
+    #[cfg(not(feature = "python"))]
     use rand::seq::SliceRandom;
     use rand::Rng;
     use std::sync::Arc;
@@ -371,16 +375,19 @@ mod codec_tests {
         vec::Vec,
     };
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn random_erasure_dense() {
         random_erasure(99_999);
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn random_erasure_sparse() {
         random_erasure(0);
     }
 
+    #[cfg(not(feature = "python"))]
     fn random_erasure(sparse_threshold: u32) {
         let elements: usize = rand::thread_rng().gen_range(1..1_000_000);
         let mut data: Vec<u8> = vec![0; elements];
@@ -413,6 +420,7 @@ mod codec_tests {
         assert_eq!(result.unwrap(), data);
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn sub_block_erasure() {
         let elements: usize = 10_000;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -74,8 +74,10 @@ pub fn calculate_block_offsets(
     #[cfg(feature = "std")]
     let kt = (config.transfer_length() as f64 / config.symbol_size() as f64).ceil() as u32;
     #[cfg(feature = "metal")]
-    let kt = (F32(config.transfer_length() as f32) / F32(config.symbol_size() as f32)).ceil().0 as u32;
-    
+    let kt = (F32(config.transfer_length() as f32) / F32(config.symbol_size() as f32))
+        .ceil()
+        .0 as u32;
+
     let (kl, ks, zl, zs) = partition(kt, config.source_blocks());
 
     let mut data_index = 0;
@@ -445,11 +447,11 @@ fn enc(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
 
     use crate::base::intermediate_tuple;
     use crate::encoder::enc;
@@ -462,10 +464,10 @@ mod tests {
     };
     #[cfg(not(any(feature = "python", feature = "wasm")))]
     use crate::{Encoder, EncoderBuilder, EncodingPacket, ObjectTransmissionInformation};
-    #[cfg(all(feature = "std", not(feature = "python"), not(feature = "wasm")))]
-    use std::collections::HashSet as Set;
     #[cfg(feature = "metal")]
     use alloc::collections::BTreeSet as Set;
+    #[cfg(all(feature = "std", not(feature = "python"), not(feature = "wasm")))]
+    use std::collections::HashSet as Set;
 
     const SYMBOL_SIZE: usize = 4;
     const NUM_SYMBOLS: u32 = 100;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -457,7 +457,9 @@ mod tests {
     use crate::systematic_constants::{
         calculate_p1, num_ldpc_symbols, systematic_index, MAX_SOURCE_SYMBOLS_PER_BLOCK,
     };
+    #[cfg(not(feature = "python"))]
     use crate::{Encoder, EncoderBuilder, EncodingPacket, ObjectTransmissionInformation};
+    #[cfg(not(feature = "python"))]
     use std::collections::HashSet;
 
     const SYMBOL_SIZE: usize = 4;
@@ -558,6 +560,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn test_builder() {
         let data = vec![0, 1, 2, 3];
@@ -567,6 +570,7 @@ mod tests {
         assert_eq!(builder.build(&data), encoder);
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn padding_constraint_exact() {
         let packet_size: u16 = 1024;
@@ -575,6 +579,7 @@ mod tests {
         padding_constraint(packet_size, padding_size, data_size);
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn padding_constraint_42_bytes() {
         let packet_size: u16 = 1024;
@@ -583,6 +588,7 @@ mod tests {
         padding_constraint(packet_size, padding_size, data_size);
     }
 
+    #[cfg(not(feature = "python"))]
     fn padding_constraint(packet_size: u16, padding_size: usize, data_size: usize) {
         let data = gen_test_data(data_size);
         let encoder = Encoder::with_defaults(&data, packet_size);
@@ -603,6 +609,7 @@ mod tests {
         assert_eq!(data[..], padded_data[..data_size]);
     }
 
+    #[cfg(not(feature = "python"))]
     #[test]
     fn unique_blocks() {
         let data = gen_test_data(120);

--- a/src/features_check/error.rs
+++ b/src/features_check/error.rs
@@ -1,0 +1,1 @@
+"raptorq requires either `std` (default) or `metal` feature enabled"

--- a/src/features_check/mod.rs
+++ b/src/features_check/mod.rs
@@ -1,0 +1,15 @@
+//! Shows a user-friendly compiler error on incompatible selected features.
+//!
+//! A neat checker shamelessly borrowed from `serde_json` crate.
+
+#[allow(unused_macros)]
+macro_rules! hide_from_rustfmt {
+    ($mod:item) => {
+        $mod
+    };
+}
+
+#[cfg(not(any(feature = "std", feature = "metal")))]
+hide_from_rustfmt! {
+    mod error;
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,10 @@
-use crate::arraymap::U16ArrayMap;
+#[cfg(feature = "std")]
 use std::cmp::{max, min};
+
+#[cfg(feature = "metal")]
+use core::cmp::{max, min};
+
+use crate::arraymap::U16ArrayMap;
 
 const NO_CONNECTED_COMPONENT: u16 = 0;
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::matrix::DenseBinaryMatrix;
 use crate::octet::Octet;
 use crate::sparse_vec::SparseBinaryVec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,17 @@
 #![allow(clippy::needless_return, clippy::unreadable_literal)]
+#![no_std]
+#![cfg(any(feature = "std", feature = "metal"))]
+
+#[cfg(feature = "metal")]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "metal")]
+extern crate core;
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 mod arraymap;
 mod base;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 #[cfg(feature = "metal")]
 extern crate core;
 
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 
@@ -42,13 +42,11 @@ pub use crate::base::partition;
 pub use crate::base::EncodingPacket;
 pub use crate::base::ObjectTransmissionInformation;
 pub use crate::base::PayloadId;
-#[cfg(not(feature = "python"))]
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 pub use crate::decoder::Decoder;
 pub use crate::decoder::SourceBlockDecoder;
 pub use crate::encoder::calculate_block_offsets;
-#[cfg(not(feature = "python"))]
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(any(feature = "python", feature = "wasm")))]
 pub use crate::encoder::Encoder;
 pub use crate::encoder::EncoderBuilder;
 pub use crate::encoder::SourceBlockEncoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::needless_return, clippy::unreadable_literal)]
 #![no_std]
-#![cfg(any(feature = "std", feature = "metal"))]
 
 #[cfg(feature = "metal")]
 #[macro_use]
@@ -13,43 +12,81 @@ extern crate core;
 #[macro_use]
 extern crate std;
 
+#[cfg(any(feature = "std", feature = "metal"))]
 mod arraymap;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod base;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod constraint_matrix;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod decoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod encoder;
+mod features_check;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod gf2;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod graph;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod iterators;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod matrix;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod octet;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod octet_matrix;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod octets;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod operation_vector;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod pi_solver;
 #[cfg(feature = "python")]
 mod python;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod rng;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod sparse_matrix;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod sparse_vec;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod symbol;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod systematic_constants;
+#[cfg(any(feature = "std", feature = "metal"))]
 mod util;
 #[cfg(feature = "wasm")]
 mod wasm;
 
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::base::partition;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::base::EncodingPacket;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::base::ObjectTransmissionInformation;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::base::PayloadId;
-#[cfg(not(any(feature = "python", feature = "wasm")))]
+#[cfg(all(
+    any(feature = "std", feature = "metal"),
+    not(feature = "python"),
+    not(feature = "wasm")
+))]
 pub use crate::decoder::Decoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::decoder::SourceBlockDecoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::encoder::calculate_block_offsets;
-#[cfg(not(any(feature = "python", feature = "wasm")))]
+#[cfg(all(
+    any(feature = "std", feature = "metal"),
+    not(feature = "python"),
+    not(feature = "wasm")
+))]
 pub use crate::encoder::Encoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::encoder::EncoderBuilder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::encoder::SourceBlockEncoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::encoder::SourceBlockEncodingPlan;
 #[cfg(feature = "python")]
 pub use crate::python::raptorq;
@@ -57,6 +94,7 @@ pub use crate::python::raptorq;
 pub use crate::python::Decoder;
 #[cfg(feature = "python")]
 pub use crate::python::Encoder;
+#[cfg(any(feature = "std", feature = "metal"))]
 pub use crate::systematic_constants::extended_source_block_symbols;
 #[cfg(feature = "wasm")]
 pub use crate::wasm::Decoder as WasmDecoder;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,9 +1,17 @@
+#[cfg(feature = "std")]
+use std::{mem::size_of, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::mem::size_of;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::gf2::add_assign_binary;
 use crate::iterators::OctetIter;
 use crate::octet::Octet;
 use crate::octets::BinaryOctetVec;
 use crate::util::get_both_ranges;
-use std::mem::size_of;
 
 // TODO: change this struct to not use the Octet class, since it's binary not GF(256)
 pub trait BinaryMatrix: Clone {

--- a/src/octet.rs
+++ b/src/octet.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "std")]
+use std::{ops::{Add, AddAssign, Div, Mul, Sub}};
+
+#[cfg(feature = "metal")]
+use core::ops::{Add, AddAssign, Div, Mul, Sub};
+
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
-use std::ops::Add;
-use std::ops::AddAssign;
-use std::ops::Div;
-use std::ops::Mul;
-use std::ops::Sub;
 
 // As defined in section 5.7.3
 #[rustfmt::skip]
@@ -71,13 +72,16 @@ pub const OCTET_MUL: [[u8; 256]; 256] = calculate_octet_mul_table();
 
 // See "Screaming Fast Galois Field Arithmetic Using Intel SIMD Instructions" by Plank et al.
 // Further adapted to AVX2
+#[cfg(any(feature = "std", test))]
 pub const OCTET_MUL_HI_BITS: [[u8; 32]; 256] = calculate_octet_mul_hi_table();
+#[cfg(any(feature = "std", test))]
 pub const OCTET_MUL_LOW_BITS: [[u8; 32]; 256] = calculate_octet_mul_low_table();
 
 const fn const_mul(x: usize, y: usize) -> u8 {
     return OCT_EXP[OCT_LOG[x] as usize + OCT_LOG[y] as usize];
 }
 
+#[cfg(any(feature = "std", test))]
 const fn calculate_octet_mul_hi_table() -> [[u8; 32]; 256] {
     let mut result = [[0; 32]; 256];
     let mut i = 1;
@@ -93,6 +97,7 @@ const fn calculate_octet_mul_hi_table() -> [[u8; 32]; 256] {
     return result;
 }
 
+#[cfg(any(feature = "std", test))]
 const fn calculate_octet_mul_low_table() -> [[u8; 32]; 256] {
     let mut result = [[0; 32]; 256];
     let mut i = 1;

--- a/src/octet.rs
+++ b/src/octet.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "std")]
-use std::{ops::{Add, AddAssign, Div, Mul, Sub}};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 #[cfg(feature = "metal")]
 use core::ops::{Add, AddAssign, Div, Mul, Sub};

--- a/src/octet_matrix.rs
+++ b/src/octet_matrix.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::octet::Octet;
 use crate::octets::{add_assign, fused_addassign_mul_scalar_binary, mulassign_scalar};
 use crate::octets::{fused_addassign_mul_scalar, BinaryOctetVec};

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -852,11 +852,11 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
 
     use crate::octet::Octet;
     use crate::octets::mulassign_scalar;

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -853,7 +853,10 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    #[cfg(feature = "std")]
     use std::vec::Vec;
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
 
     use crate::octet::Octet;
     use crate::octets::mulassign_scalar;

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -1,21 +1,33 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::octet::Octet;
 use crate::octet::OCTET_MUL;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64"
+#[cfg(all(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+    ),
+    feature = "std"
 ))]
 use crate::octet::OCTET_MUL_HI_BITS;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64"
+#[cfg(all(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+    ),
+    feature = "std"
 ))]
 use crate::octet::OCTET_MUL_LOW_BITS;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "std"))]
 use std::arch::is_aarch64_feature_detected;
 
 // An octet vec containing only binary values, which are bit-packed for efficiency
@@ -89,7 +101,7 @@ pub fn fused_addassign_mul_scalar_binary(
     );
 
     assert_eq!(octets.len(), other.len());
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {
         if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("bmi1") {
             unsafe {
@@ -97,7 +109,7 @@ pub fn fused_addassign_mul_scalar_binary(
             }
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     {
         if is_aarch64_feature_detected!("neon") {
             unsafe {
@@ -105,7 +117,7 @@ pub fn fused_addassign_mul_scalar_binary(
             }
         }
     }
-    #[cfg(target_arch = "arm")]
+    #[cfg(all(target_arch = "arm", feature = "std"))]
     {
         // TODO: enable when stable
         // if is_arm_feature_detected!("neon") {
@@ -195,7 +207,7 @@ unsafe fn fused_addassign_mul_scalar_binary_neon(
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "avx2")]
 #[target_feature(enable = "bmi1")]
 unsafe fn fused_addassign_mul_scalar_binary_avx2(
@@ -318,7 +330,7 @@ unsafe fn mulassign_scalar_neon(octets: &mut [u8], scalar: &Octet) {
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "avx2")]
 unsafe fn mulassign_scalar_avx2(octets: &mut [u8], scalar: &Octet) {
     #[cfg(target_arch = "x86")]
@@ -360,7 +372,7 @@ unsafe fn mulassign_scalar_avx2(octets: &mut [u8], scalar: &Octet) {
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "ssse3")]
 unsafe fn mulassign_scalar_ssse3(octets: &mut [u8], scalar: &Octet) {
     #[cfg(target_arch = "x86")]
@@ -401,7 +413,7 @@ unsafe fn mulassign_scalar_ssse3(octets: &mut [u8], scalar: &Octet) {
 }
 
 pub fn mulassign_scalar(octets: &mut [u8], scalar: &Octet) {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {
         if is_x86_feature_detected!("avx2") {
             unsafe {
@@ -414,7 +426,7 @@ pub fn mulassign_scalar(octets: &mut [u8], scalar: &Octet) {
             }
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     {
         if is_aarch64_feature_detected!("neon") {
             unsafe {
@@ -422,7 +434,7 @@ pub fn mulassign_scalar(octets: &mut [u8], scalar: &Octet) {
             }
         }
     }
-    #[cfg(target_arch = "arm")]
+    #[cfg(all(target_arch = "arm", feature = "std"))]
     {
         // TODO: enable when stable
         // if is_arm_feature_detected!("neon") {
@@ -493,7 +505,7 @@ unsafe fn fused_addassign_mul_scalar_neon(octets: &mut [u8], other: &[u8], scala
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "avx2")]
 unsafe fn fused_addassign_mul_scalar_avx2(octets: &mut [u8], other: &[u8], scalar: &Octet) {
     #[cfg(target_arch = "x86")]
@@ -542,7 +554,7 @@ unsafe fn fused_addassign_mul_scalar_avx2(octets: &mut [u8], other: &[u8], scala
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "ssse3")]
 unsafe fn fused_addassign_mul_scalar_ssse3(octets: &mut [u8], other: &[u8], scalar: &Octet) {
     #[cfg(target_arch = "x86")]
@@ -602,7 +614,7 @@ pub fn fused_addassign_mul_scalar(octets: &mut [u8], other: &[u8], scalar: &Octe
     );
 
     assert_eq!(octets.len(), other.len());
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {
         if is_x86_feature_detected!("avx2") {
             unsafe {
@@ -615,7 +627,7 @@ pub fn fused_addassign_mul_scalar(octets: &mut [u8], other: &[u8], scalar: &Octe
             }
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     {
         if is_aarch64_feature_detected!("neon") {
             unsafe {
@@ -623,7 +635,7 @@ pub fn fused_addassign_mul_scalar(octets: &mut [u8], other: &[u8], scalar: &Octe
             }
         }
     }
-    #[cfg(target_arch = "arm")]
+    #[cfg(all(target_arch = "arm", feature = "std"))]
     {
         // TODO: enable when stable
         // if is_arm_feature_detected!("neon") {
@@ -681,7 +693,7 @@ unsafe fn store_neon(ptr: *mut uint8x16_t, value: uint8x16_t) {
     *(ptr as *mut u64).add(1) = vgetq_lane_u64(reinterp, 1);
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "std"))]
 // TODO: enable when stable
 // #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 // #[target_feature(enable = "neon")]
@@ -724,7 +736,7 @@ unsafe fn add_assign_neon(octets: &mut [u8], other: &[u8]) {
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "avx2")]
 unsafe fn add_assign_avx2(octets: &mut [u8], other: &[u8]) {
     #[cfg(target_arch = "x86")]
@@ -764,7 +776,7 @@ unsafe fn add_assign_avx2(octets: &mut [u8], other: &[u8]) {
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[target_feature(enable = "ssse3")]
 unsafe fn add_assign_ssse3(octets: &mut [u8], other: &[u8]) {
     #[cfg(target_arch = "x86")]
@@ -805,7 +817,7 @@ unsafe fn add_assign_ssse3(octets: &mut [u8], other: &[u8]) {
 }
 
 pub fn add_assign(octets: &mut [u8], other: &[u8]) {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
     {
         if is_x86_feature_detected!("avx2") {
             unsafe {
@@ -818,7 +830,7 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
             }
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "std"))]
     {
         if is_aarch64_feature_detected!("neon") {
             unsafe {
@@ -826,7 +838,7 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
             }
         }
     }
-    #[cfg(target_arch = "arm")]
+    #[cfg(all(target_arch = "arm", feature = "std"))]
     {
         // TODO: enable when stable
         // if is_arm_feature_detected!("neon") {
@@ -841,6 +853,7 @@ pub fn add_assign(octets: &mut [u8], other: &[u8]) {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    use std::vec::Vec;
 
     use crate::octet::Octet;
     use crate::octets::mulassign_scalar;

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::octet::Octet;
 use crate::symbol::Symbol;
 use crate::util::get_both_indices;
@@ -56,6 +62,7 @@ pub fn perform_op(op: &SymbolOps, symbols: &mut Vec<Symbol>) {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    use std::vec::Vec;
 
     use crate::octet::Octet;
     use crate::operation_vector::{perform_op, SymbolOps};

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -61,11 +61,11 @@ pub fn perform_op(op: &SymbolOps, symbols: &mut Vec<Symbol>) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
 
     use crate::octet::Octet;
     use crate::operation_vector::{perform_op, SymbolOps};

--- a/src/operation_vector.rs
+++ b/src/operation_vector.rs
@@ -62,7 +62,10 @@ pub fn perform_op(op: &SymbolOps, symbols: &mut Vec<Symbol>) {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    #[cfg(feature = "std")]
     use std::vec::Vec;
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
 
     use crate::octet::Octet;
     use crate::operation_vector::{perform_op, SymbolOps};

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -1,3 +1,12 @@
+#[cfg(feature = "std")]
+use std::{u16, mem, mem::size_of, vec::Vec};
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "metal")]
+use core::{u16, mem, mem::size_of};
+
 use crate::arraymap::UndirectedGraph;
 use crate::arraymap::{U16ArrayMap, U32VecMap};
 use crate::graph::ConnectedComponentGraph;
@@ -12,7 +21,6 @@ use crate::systematic_constants::num_intermediate_symbols;
 use crate::systematic_constants::num_ldpc_symbols;
 use crate::systematic_constants::num_pi_symbols;
 use crate::util::get_both_indices;
-use std::mem::size_of;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 enum RowOp {
@@ -339,7 +347,7 @@ impl FirstPhaseRowSelectionStats {
         // There's no need for special handling of HDPC rows, since Errata 2 guarantees we won't
         // select any, and they're excluded in the first_phase solver
         let mut chosen = None;
-        let mut chosen_original_degree = std::u16::MAX;
+        let mut chosen_original_degree = u16::MAX;
         // Fast path for r=1, since this is super common
         if r == 1 {
             assert_ne!(0, self.rows_with_single_one.len());
@@ -1311,7 +1319,7 @@ impl<T: BinaryMatrix> IntermediateSymbolDecoder<T> {
             reorder.push(*i);
         }
 
-        let mut operation_vector = std::mem::take(&mut self.deferred_D_ops);
+        let mut operation_vector = mem::take(&mut self.deferred_D_ops);
         operation_vector.push(SymbolOps::Reorder { order: reorder });
         return (Some(result), Some(operation_vector));
     }
@@ -1330,6 +1338,7 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
     use super::IntermediateSymbolDecoder;
     use crate::constraint_matrix::generate_constraint_matrix;
     use crate::matrix::BinaryMatrix;

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "std")]
-use std::{u16, mem, mem::size_of, vec::Vec};
+use std::{mem, mem::size_of, u16, vec::Vec};
 
 #[cfg(feature = "metal")]
 use alloc::vec::Vec;
 
 #[cfg(feature = "metal")]
-use core::{u16, mem, mem::size_of};
+use core::{mem, mem::size_of, u16};
 
 use crate::arraymap::UndirectedGraph;
 use crate::arraymap::{U16ArrayMap, U32VecMap};
@@ -1338,10 +1338,6 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "std")]
-    use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
     use super::IntermediateSymbolDecoder;
     use crate::constraint_matrix::generate_constraint_matrix;
     use crate::matrix::BinaryMatrix;
@@ -1351,6 +1347,10 @@ mod tests {
         extended_source_block_symbols, num_ldpc_symbols, num_lt_symbols,
         MAX_SOURCE_SYMBOLS_PER_BLOCK,
     };
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
+    #[cfg(feature = "std")]
+    use std::vec::Vec;
 
     #[test]
     fn operations_per_symbol() {

--- a/src/pi_solver.rs
+++ b/src/pi_solver.rs
@@ -1338,7 +1338,10 @@ pub fn fused_inverse_mul_symbols<T: BinaryMatrix>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use std::vec::Vec;
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use super::IntermediateSymbolDecoder;
     use crate::constraint_matrix::generate_constraint_matrix;
     use crate::matrix::BinaryMatrix;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,3 +1,5 @@
+use std::vec::Vec;
+
 use crate::base::{EncodingPacket, ObjectTransmissionInformation};
 use crate::decoder::Decoder as DecoderNative;
 use crate::encoder::Encoder as EncoderNative;

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -1,3 +1,12 @@
+#[cfg(feature = "std")]
+use std::{mem::size_of, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::mem::size_of;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::arraymap::{ImmutableListMap, ImmutableListMapBuilder};
 use crate::iterators::OctetIter;
 use crate::matrix::BinaryMatrix;
@@ -5,7 +14,6 @@ use crate::octet::Octet;
 use crate::octets::BinaryOctetVec;
 use crate::sparse_vec::SparseBinaryVec;
 use crate::util::get_both_indices;
-use std::mem::size_of;
 
 // Stores a matrix in sparse representation, with an optional dense block for the right most columns
 // The logical storage is as follows:

--- a/src/sparse_vec.rs
+++ b/src/sparse_vec.rs
@@ -1,6 +1,13 @@
+#[cfg(feature = "std")]
+use std::{cmp::Ordering, mem::size_of, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::{cmp::Ordering, mem::size_of};
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::octet::Octet;
-use std::cmp::Ordering;
-use std::mem::size_of;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct SparseBinaryVec {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,10 +1,18 @@
+#[cfg(feature = "std")]
+use std::{ops::AddAssign, vec::Vec};
+
+#[cfg(feature = "metal")]
+use core::ops::AddAssign;
+
+#[cfg(feature = "metal")]
+use alloc::vec::Vec;
+
 use crate::octet::Octet;
 use crate::octets::add_assign;
 use crate::octets::fused_addassign_mul_scalar;
 use crate::octets::mulassign_scalar;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
-use std::ops::AddAssign;
 
 /// Elementary unit of data, for encoding/decoding purposes.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -61,6 +69,7 @@ impl<'a> AddAssign<&'a Symbol> for Symbol {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    use std::vec::Vec;
 
     use crate::symbol::Symbol;
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -68,11 +68,11 @@ impl<'a> AddAssign<&'a Symbol> for Symbol {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
     use rand::Rng;
     #[cfg(feature = "std")]
     use std::vec::Vec;
-    #[cfg(feature = "metal")]
-    use alloc::vec::Vec;
 
     use crate::symbol::Symbol;
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -69,7 +69,10 @@ impl<'a> AddAssign<&'a Symbol> for Symbol {
 #[cfg(test)]
 mod tests {
     use rand::Rng;
+    #[cfg(feature = "std")]
     use std::vec::Vec;
+    #[cfg(feature = "metal")]
+    use alloc::vec::Vec;
 
     use crate::symbol::Symbol;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,3 +1,5 @@
+use std::vec::Vec;
+
 use crate::base::{EncodingPacket, ObjectTransmissionInformation};
 use crate::decoder::Decoder as DecoderNative;
 use crate::encoder::Encoder as EncoderNative;


### PR DESCRIPTION
`metal` feature supports `no_std` in configuration `default-features = false, features = ["metal"]`.
Float calculation is done via `micromath` crate.

All previously available functionality remains under default `std` feature.

Some tweaking of `python` and `wasm` features was done to compile tests.